### PR TITLE
Changing minimum minor version of nyholm/psr7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
   ],
   "require": {
     "php": ">=8.1",
-    "nyholm/psr7": "^1.1",
+    "nyholm/psr7": "^1.4",
     "spiral/http": "^3.0",
     "spiral/boot": "^3.0"
   },


### PR DESCRIPTION
Since version `1.4.0` the Response: https://github.com/Nyholm/psr7/blob/1.4.0/src/Response.php class is not final. In some cases, it needs to be expanded.
